### PR TITLE
Send signed messages over black-lager firmware port

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -730,7 +730,11 @@ class MeshInterface:
                  hopLimit=None,
                  onResponse=None,
                  channelIndex=0):
-        """Send a signed text message to another node"""
+        """
+        Send a signed text message to another node using the black lager module.
+        This function signs the text message with the users private key and sets
+        the payload of the packet to be the signed text message data.
+        """
         if hopLimit is None:
             hopLimit = self.defaultHopLimit
 

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -722,3 +722,22 @@ class MeshInterface:
         logging.debug(f"Publishing {topic}: packet={stripnl(asDict)} ")
         publishingThread.queueWork(lambda: pub.sendMessage(
             topic, packet=asDict, interface=self))
+
+    def sendSignedText(self, text: AnyStr,
+                 destinationId=BROADCAST_ADDR,
+                 wantAck=False,
+                 wantResponse=False,
+                 hopLimit=None,
+                 onResponse=None,
+                 channelIndex=0):
+        """Send a signed text message to another node"""
+        if hopLimit is None:
+            hopLimit = self.defaultHopLimit
+
+        return self.sendData(text.encode("utf-8"), destinationId,
+                             portNum=portnums_pb2.PortNum.PRIVATE_APP,
+                             wantAck=wantAck,
+                             wantResponse=wantResponse,
+                             hopLimit=hopLimit,
+                             onResponse=onResponse,
+                             channelIndex=channelIndex)


### PR DESCRIPTION
Close #3 

Implement a function to send signed text messages to the device over the black-lager port