### PR TITLE
Configure GitHub actions to create pull request on protobuf update

### DIFF
--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -26,3 +26,8 @@ jobs:
           ./bin/regen-protobufs.sh
 
       - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          add-paths: |
+            protobufs
+            meshtastic

--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -25,11 +25,4 @@ jobs:
         run: |
           ./bin/regen-protobufs.sh
 
-      - name: Commit update
-        run: |
-          git config --global user.name 'github-actions'
-          git config --global user.email 'bot@noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git add protobufs
-          git add meshtastic
-          git commit -m "Update protobuf submodule" && git push || echo "No changes to commit"
+      - name: Create pull request

--- a/.github/workflows/update_protobufs.yml
+++ b/.github/workflows/update_protobufs.yml
@@ -1,4 +1,4 @@
-name: "Update protobufs"
+name: 'Update protobufs'
 on: workflow_dispatch
 
 jobs:
@@ -11,10 +11,9 @@ jobs:
         with:
           submodules: true
 
-      - name: Update Submodule
+      - name: Update submodule
         run: |
-          git pull --recurse-submodules
-          git submodule update --remote --recursive
+          git submodule update --remote protobufs
 
       - name: Download nanopb
         run: |


### PR DESCRIPTION
Close #8 

The previous behavior was for the GitHub action to try and commit the protobuf change to the main branch, so the GitHub actions were failing because the main branch is protected.

Updated the GitHub action to create a pull request instead when updating protobufs.