### PR TITLE
Fix encoding of signed text messages

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -177,11 +177,9 @@ def _receiveInfoUpdate(iface, asDict):
 def _onSignedTextReceive(iface, asDict):
     """Parsing for received signed text messages"""
     logging.debug(f'in _onSignedTextReceive() asDict:{asDict}')
-    try:
-        asBytes = asDict["decoded"]["payload"]
-        asDict["decoded"]["signed-text"] = asBytes
-    except Exception as ex:
-        logging.error(f"Malformatted utf8 in text message: {ex}")
+    asBytes = asDict["decoded"]["payload"]
+    asDict["decoded"]["signed-text"] = asBytes
+
     _receiveInfoUpdate(iface, asDict)
 
 

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -179,7 +179,7 @@ def _onSignedTextReceive(iface, asDict):
     logging.debug(f'in _onSignedTextReceive() asDict:{asDict}')
     try:
         asBytes = asDict["decoded"]["payload"]
-        asDict["decoded"]["signed-text"] = asBytes.decode("utf-8")
+        asDict["decoded"]["signed-text"] = asBytes
     except Exception as ex:
         logging.error(f"Malformatted utf8 in text message: {ex}")
     _receiveInfoUpdate(iface, asDict)

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -723,7 +723,8 @@ class MeshInterface:
         publishingThread.queueWork(lambda: pub.sendMessage(
             topic, packet=asDict, interface=self))
 
-    def sendSignedText(self, text: AnyStr,
+# TODO: take the clear text message and signing key as parameters here and do the signing in this function
+    def sendSignedText(self, signedMessage: bytes,
                  destinationId=BROADCAST_ADDR,
                  wantAck=False,
                  wantResponse=False,
@@ -738,7 +739,7 @@ class MeshInterface:
         if hopLimit is None:
             hopLimit = self.defaultHopLimit
 
-        return self.sendData(text.encode("utf-8"), destinationId,
+        return self.sendData(signedMessage, destinationId,
                              portNum=portnums_pb2.PortNum.BLACK_LAGER,
                              wantAck=wantAck,
                              wantResponse=wantResponse,


### PR DESCRIPTION
Close #14 

Signed text messages are now treated as bytes and not encoded and decoded into UTF-8. Note that the actual contents of the message can still be UTF-8 encoded, but the packet as a whole should not be.